### PR TITLE
Add support for port numbers as integers

### DIFF
--- a/sabridge/base.py
+++ b/sabridge/base.py
@@ -82,7 +82,7 @@ def urlbuild(scheme, path, username=None, password=None, hostname=None, port=Non
         netloc.append(hostname)
     if port:
         netloc.append(':')
-        netloc.append(port)
+        netloc.append(str(port))
 
     # put it all together
     return '{scheme}://{netloc}/{path}'.format(scheme=scheme,

--- a/tests/tests/test_base.py
+++ b/tests/tests/test_base.py
@@ -19,6 +19,10 @@ class URLBuildTest(TestCase):
                                   username='scott', password='tiger'),
                          'postgresql://scott:tiger@10.0.0.1:5432/test')
 
+    def test_int_port(self):
+        self.assertEqual(urlbuild('postgresql', 'test', hostname='10.0.0.1', port=5433),
+                         'postgresql://10.0.0.1:5433/test')
+
 
 class BridgeTest(TransactionTestCase):
     # Must use a TransactionTestCase so that inside a test, writes from Django


### PR DESCRIPTION
These are allowed to be ints too, not just strings, so cast to a string before joining.
